### PR TITLE
refactor: logger path

### DIFF
--- a/config/php-di.php
+++ b/config/php-di.php
@@ -87,7 +87,7 @@ return array(
 	'message.logger.active'       => function (Container $container ) {
 		return (bool) $container->make( 'zgw.settings', array( 'owc-mijn-services-enable-logging' ) );
 	},
-	'message.logger.path'         => sprintf( '%s/owc-my-services-log.json', wp_get_upload_dir()['basedir'] ),
+	'message.logger.path'         => sprintf( '%s/owc-my-services-log.json', dirname( ABSPATH ) ),
 	'message.logger'              => function (Container $container ) {
 		$logger   = new \Monolog\Logger( 'owc_my_services_log' );
 		$maxFiles = apply_filters( 'owcms::logger/rotating_filer_handler_max_files', OWC_MY_SERVICES_LOGGER_DEFAULT_MAX_FILES );


### PR DESCRIPTION
Er wordt alleen gelogd als de [instelling](https://github.com/OpenWebconcept/plugin-owc-mijn-services/blob/main/src/LoggerZGW.php#L83) daarvan aan staat.

Voor de context, de inhoud van het log bestand:
`{"message":"OWC\\My_Services: Rendering single zaak block","context":{},"level":400,"level_name":"ERROR","channel":"owc_my_services_log","datetime":"2025-10-21T15:25:34.579374+00:00","extra":{"file":null,"line":null,"class":"OWC\\My_Services\\LoggerZGW","callType":"->","function":"add_record"}}`

En de nieuwe locatie van het log bestand:
<img width="689" height="171" alt="Scherm­afbeelding 2025-10-21 om 17 25 59" src="https://github.com/user-attachments/assets/a1d2bb06-93bc-4d31-b369-ff03c3f44966" />
